### PR TITLE
#7739 Plugin local_bulkenrol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ env:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install 8.9
-  - nvm use 8.9
+  - nvm install node
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
@@ -42,7 +41,7 @@ script:
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
-  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci codechecker || true # Output warnings but do not fail the build because of working legacy code
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache

--- a/bulkenrol_form.php
+++ b/bulkenrol_form.php
@@ -1,0 +1,40 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once $CFG->libdir.'/formslib.php';
+
+class local_bulkenrol_form extends moodleform {
+    
+    function definition () {
+        global $CFG;
+        
+        require_once($CFG->dirroot.'/local/bulkenrol/lib.php');
+        
+        $mform = $this->_form;
+        
+        // Infotext
+        $msg = get_string('infotext','local_bulkenrol');
+        $mform->addElement('html', '<div class="local_bulkenrol infotext">'.$msg.'</div>');
+        
+        // Textarea für Emails
+        $mform->addElement('textarea', 'usermails', get_string('usermails', 'local_bulkenrol'), 'wrap="virtual" rows="10" cols="80"');
+        $mform->addRule('usermails', null, 'required');
+        
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_RAW);
+        $mform->setDefault('id', $this->_customdata['courseid']);
+        
+        $this->add_action_buttons(true, get_string('submit'));
+    }
+    
+    function validation($data, $files) {
+        $retval = array();
+        
+        if(empty($data['usermails'])){
+            $retval['usermails'] = get_string('usermails_empty', 'local_bulkenrol');
+        }
+        
+        return $retval;
+    }
+}

--- a/confirm_form.php
+++ b/confirm_form.php
@@ -1,0 +1,25 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once $CFG->libdir.'/formslib.php';
+
+class local_bulkenrol_confirm_form extends moodleform {
+    
+    function definition () {
+        $local_bulkenrol_key = $this->_customdata['local_bulkenrol_key'];
+        $courseid = $this->_customdata['courseid'];
+        
+        $mform = $this->_form;
+        
+        $mform->addElement('hidden', 'key');
+        $mform->setType('key', PARAM_RAW);
+        $mform->setDefault('key', $local_bulkenrol_key);
+        
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_INT);
+        $mform->setDefault('id', $courseid);
+        
+        $this->add_action_buttons(true, get_string('enrol_users', 'local_bulkenrol'));
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Local plugin "bulkenrol" - Capabilities
+ *
+ * @package   local_bulkenrol
+ * @copyright 2017 Soon Systems GmbH on behalf of Alexander Bias, Ulm University <alexander.bias@uni-ulm.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = array(
+    'local/bulkenrol:enrolusers' => array(
+        'riskbitmask' => RISK_XSS,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE
+    ),
+);

--- a/index.php
+++ b/index.php
@@ -1,0 +1,135 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Seite Einschreiben von Usern anhand einer Emailliste
+ *
+ * @package    local
+ * @subpackage bulkenrol
+ * @copyright  2017 Soon-Systems GmbH {@link https://soon-systems.de}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once('../../config.php');
+require_once($CFG->libdir.'/adminlib.php');
+require_once($CFG->dirroot.'/local/bulkenrol/lib.php');
+require_once($CFG->dirroot.'/local/bulkenrol/bulkenrol_form.php');
+require_once($CFG->dirroot.'/local/bulkenrol/confirm_form.php');
+
+
+###################################################################
+
+$id     = optional_param('id', 0, PARAM_INT); // This are required.
+$local_bulkenrol_key = optional_param('key', 0, PARAM_RAW);
+
+$context = context_system::instance();
+
+if(!empty($id)){
+    $course = $DB->get_record('course', array('id' => $id), '*', MUST_EXIST);
+    $context = context_course::instance($course->id, MUST_EXIST);
+    
+    $PAGE->set_context($context);
+    $PAGE->set_url('/local/bulkenrol/index.php', array('id' => $id));
+    $PAGE->set_title("$course->shortname: ".get_string('pluginname', 'local_bulkenrol'));
+    $PAGE->set_heading($course->fullname);
+    
+    
+    require_login($course);
+}
+
+if (!has_capability('local/bulkenrol:enrolusers', $context)) {
+    print_error('nopermissions', 'error', '', 'local/bulkenrol:enrolusers');
+}
+
+$PAGE->set_pagelayout('incourse');
+
+
+if(empty($local_bulkenrol_key)){
+    $form = new local_bulkenrol_form(null, array('courseid' => $id));
+    if ($formdata = $form->get_data()) {
+        $emails = $formdata->usermails;
+        $courseid = $formdata->id;
+        
+        $checked_mails = local_bulkenrol_check_user_mails($emails);
+        
+        // Create local_bulkenrol array in Session
+        if(!isset($SESSION->local_bulkenrol)){
+            $SESSION->local_bulkenrol = array();
+        }
+        // Save data in Session
+        $local_bulkenrol_key = $courseid.'_'.time();
+        $SESSION->local_bulkenrol[$local_bulkenrol_key] = $checked_mails;
+        
+    } 
+    else if($form->is_cancelled()){
+        if(!empty($id)){
+            redirect($CFG->wwwroot .'/course/view.php?id='.$id, '', 0);
+        }
+        else{
+            redirect($CFG->wwwroot, '', 0);
+        }
+    }
+    else {
+        echo $OUTPUT->header();
+        echo $OUTPUT->heading(get_string('pluginname', 'local_bulkenrol'));
+        echo $form->display();
+        echo $OUTPUT->footer();
+    }
+}
+
+if ($local_bulkenrol_key) {
+    $form2 = new local_bulkenrol_confirm_form(null, array('local_bulkenrol_key' => $local_bulkenrol_key, 'courseid' => $id));
+    
+    if ($formdata = $form2->get_data()) {
+        global $SESSION;
+    
+        if(!empty($local_bulkenrol_key) && !empty($SESSION->local_bulkenrol) && array_key_exists($local_bulkenrol_key, $SESSION->local_bulkenrol)){
+            set_time_limit(600);
+    
+//             echo $OUTPUT->header();
+//             echo $OUTPUT->heading(get_string('pluginname', 'local_bulkenrol'));
+            
+            local_bulkenrol_users($local_bulkenrol_key);
+    
+            redirect($CFG->wwwroot .'/local/bulkenrol/index.php?id='.$id, '', 0);
+//             echo $OUTPUT->footer();
+        }
+        else{
+            redirect($CFG->wwwroot .'/local/bulkenrol/index.php?id='.$id, '', 0);
+        }
+    }
+    else if($form2->is_cancelled()){
+        redirect($CFG->wwwroot .'/local/bulkenrol/index.php?id='.$id, '', 0);
+    }
+    else {
+        
+        $PAGE->set_url('/local/bulkenrol/index.php', array('id' => $id));
+        
+        echo $OUTPUT->header();
+        echo $OUTPUT->heading(get_string('pluginname', 'local_bulkenrol'));
+        if(!empty($local_bulkenrol_key) && !empty($SESSION->local_bulkenrol) && array_key_exists($local_bulkenrol_key, $SESSION->local_bulkenrol)){
+            $local_bulkenrol_data = $SESSION->local_bulkenrol[$local_bulkenrol_key];
+    
+            if(!empty($local_bulkenrol_data)){
+                local_bulkenrol_display_table($local_bulkenrol_data, LOCALBULKENROL_HINT);
+                local_bulkenrol_display_table($local_bulkenrol_data, LOCALBULKENROL_ENROLUSERS);
+            }
+        }
+    
+        echo $form2->display();
+        echo $OUTPUT->footer();
+    }
+}

--- a/lang/de/local_bulkenrol.php
+++ b/lang/de/local_bulkenrol.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Local plugin "bulkenrol" - Language pack
+ *
+ * @package   local_bulkenrol
+ * @copyright 2017 Soon Systems GmbH on behalf of Alexander Bias, Ulm University <alexander.bias@uni-ulm.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'Bulkenrol';
+
+$string['bulkenrol_auth'] = 'Emails';
+
+$string['bulkenrol_enrolment'] = 'Bulkenrol Plugin';
+$string['bulkenrol_enrolment_description'] = 'Das für die Einschreibungen zu nutzende Einschreibeplugin. Falls das konfigurierte Einschreibeplugin nicht aktiv ist im Kurs wird es während des Imports aktiviert / hinzugefügt.';
+
+$string['infotext'] = 'Hier kommt der Hinweistext mit Nutzungshinweisen zum Plugin';
+$string['usermails'] = 'Emails';
+
+$string['hints_label'] = 'Hinweise';
+$string['row'] = 'Zeile';
+$string['users_to_enrol_in_course_label'] = 'In den Kurs einzuschreibende Nutzer';
+$string['enrol_users'] = 'Nutzer einschreiben';
+$string['enrol_users_successful'] = 'Nutzer Einschreibung erfolgreich';
+
+// Errors
+$string['no_email'] = 'Keine Email in Zeile {$a->line} -> "{$a->content}"';
+$string['invalid_email'] = 'Ungültige Email in Zeile {$a->row}: "{$a->email}" -> Email-Adresse wird ignoriert';
+$string['more_than_one_record_for_email'] = 'Mehr als ein Moodle-User für Email "{$a}" -> Email-Adresse wird ignoriert und keiner der Nutzer mit dieser Email wird eingeschrieben.';
+$string['no_record_found_for_email'] = 'Kein Moodle-User für Email "{$a}" -> Email-Adresse wird ignoriert und es wird kein neuer Nutzer angelegt.';
+$string['error_getting_user_for_email'] = 'Fehler beim Abfragen der DB nach User zur Email "{$a}".';
+$string['exception_info'] = 'Exception info';
+$string['error_enrol_users'] = 'Fehler beim Einschreiben der User in den Kurs.';
+$string['error_group_add_members'] = 'Fehler beim Einschreiben der User in Kursgruppen.';
+
+$string['no_data'] = 'Keine Benutzer zum Einschreiben in den Kurs.';
+$string['no_courseid_or_no_users_to_enrol'] = 'Keine KursId oder keine Benutzer zum Einschreiben in den Kurs.';
+
+$string['usermails_empty'] = 'Keine Emails eingetragen';
+

--- a/lang/en/local_bulkenrol.php
+++ b/lang/en/local_bulkenrol.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Local plugin "bulkenrol" - Language pack
+ *
+ * @package   local_bulkenrol
+ * @copyright 2017 Soon Systems GmbH on behalf of Alexander Bias, Ulm University <alexander.bias@uni-ulm.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'Bulkenrol';
+
+$string['bulkenrol_auth'] = 'Emails';
+
+$string['bulkenrol_enrolment'] = 'Bulkenrol Plugin';
+$string['bulkenrol_enrolment_description'] = 'Das für die Einschreibungen zu nutzende Einschreibeplugin. Falls das konfigurierte Einschreibeplugin nicht aktiv ist im Kurs wird es während des Imports aktiviert / hinzugefügt.';
+
+$string['infotext'] = 'Hier kommt der Hinweistext mit Nutzungshinweisen zum Plugin';
+$string['usermails'] = 'Emails';
+
+$string['hints_label'] = 'Hinweise';
+$string['row'] = 'Zeile';
+$string['users_to_enrol_in_course_label'] = 'In den Kurs einzuschreibende Nutzer';
+$string['enrol_users'] = 'Nutzer einschreiben';
+$string['enrol_users_successful'] = 'Nutzer Einschreibung erfolgreich';
+
+// Errors
+$string['no_email'] = 'Keine Email in Zeile {$a->line} -> "{$a->content}"';
+$string['invalid_email'] = 'Ungültige Email in Zeile {$a->row}: "{$a->email}" -> Email-Adresse wird ignoriert';
+$string['more_than_one_record_for_email'] = 'Mehr als ein Moodle-User für Email "{$a}" -> Email-Adresse wird ignoriert und keiner der Nutzer mit dieser Email wird eingeschrieben.';
+$string['no_record_found_for_email'] = 'Kein Moodle-User für Email "{$a}" -> Email-Adresse wird ignoriert und es wird kein neuer Nutzer angelegt.';
+$string['error_getting_user_for_email'] = 'Fehler beim Abfragen der DB nach User zur Email "{$a}".';
+$string['exception_info'] = 'Exception info';
+$string['error_enrol_users'] = 'Fehler beim Einschreiben der User in den Kurs.';
+$string['error_group_add_members'] = 'Fehler beim Einschreiben der User in Kursgruppen.';
+
+$string['no_data'] = 'Keine Benutzer zum Einschreiben in den Kurs.';
+$string['no_courseid_or_no_users_to_enrol'] = 'Keine KursId oder keine Benutzer zum Einschreiben in den Kurs.';
+
+$string['usermails_empty'] = 'Keine Emails eingetragen';
+

--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,491 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Local plugin "bulkenrol" - Library
+ *
+ * @package   local_bulkenrol
+ * @copyright 2017 Soon Systems GmbH on behalf of Alexander Bias, Ulm University <alexander.bias@uni-ulm.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+
+define("LOCALBULKENROL_HINT", 'hint');
+define("LOCALBULKENROL_ENROLUSERS", 'enrolusers');
+
+/**
+ * @param unknown $emails textfield value to be checked for emails
+ * @return stdClass Object containing information to be displayed on confirm page and being used for bulkenrol 
+ */
+function local_bulkenrol_check_user_mails($emails_textfield) {
+
+    $checked_emails = new stdClass();
+    $checked_emails->emails_to_ignore = array();
+    $checked_emails->error_messages = array();          // [line]->message
+    $checked_emails->moodleusers_for_email = array();   // [email]->user
+    $checked_emails->course_groups = array();   // course groups
+    
+    
+    $email_delimiters = array(', ', ' ', ',');
+    
+    if(!empty($emails_textfield)){
+        $emails_lines = local_bulkenrol_parse_emails($emails_textfield);
+        
+        $line_cnt = 0;
+        
+        $current_group = '';
+        
+        // process emails from textfield
+        foreach ($emails_lines as $email_line) {
+            $line_cnt++;
+            
+            $email_line = trim($email_line);
+            
+            // check for course group
+            $group_pos = strpos($email_line , '#');
+            if($group_pos !== false){
+                $groupname = substr($email_line, $group_pos+1);
+                $current_group = trim($groupname);
+                $checked_emails->course_groups[$current_group] = array();
+                continue;
+            }
+            
+            
+            // check number of emails in current row/line
+            $emails_in_line_cnt = substr_count($email_line , '@');
+            
+            // no email in row/line
+            if($emails_in_line_cnt == 0){
+                $a = new stdClass();
+                $a->line = $line_cnt;
+                $a->content = $email_line;
+                $error = get_string('no_email', 'local_bulkenrol', $a);
+                $checked_emails->error_messages[$line_cnt] = $error;
+            }
+            // one email in row/line
+            else if($emails_in_line_cnt == 1){
+                $email = $email_line;
+                
+                // check for valid email
+                $email_is_valid = validate_email($email);
+                
+                // email is not valid
+                if(!$email_is_valid){
+                    $a = new stdClass();
+                    $a->row = $line_cnt;
+                    $a->email = $email;
+                    $error = get_string('invalid_email', 'local_bulkenrol', $a);
+                    $checked_emails->error_messages[$line_cnt] = $error;
+                    $checked_emails->emails_to_ignore[] = $email;
+                }
+                // email is valid
+                else{
+                    // check for moodle user with email
+                    list($error, $user_record) = local_bulkenrol_get_user($email);
+                    
+                    if(!empty($error)){
+                        $checked_emails->error_messages[$line_cnt] = $error;
+                        $checked_emails->emails_to_ignore[] = $email;
+                    }
+                    else if(!empty($user_record) && !empty($user_record->id)){
+                        $checked_emails->moodleusers_for_email[$email] = $user_record;
+                        
+                        if(!empty($current_group) && array_key_exists($current_group, $checked_emails->course_groups)){
+                            $checked_emails->course_groups[$current_group][] = $user_record;
+                        }
+                    }
+                }
+            }
+            // more than one email in row/line
+            if($emails_in_line_cnt > 1){
+                $delimiter = '';
+                
+                // check delimiters
+                foreach ($email_delimiters as $email_delimiter) {
+                    $pos = strpos($email_line, $email_delimiter);
+                    if($pos){
+                        $delimiter = $email_delimiter;
+                        break;
+                    }
+                }
+                if(!empty($delimiter)){
+                    $emails_in_line = explode($delimiter, $email_line);
+                    
+                    // iterate emails in row/line
+                    foreach ($emails_in_line as $email_in_line){
+                        
+                        $email = trim($email_in_line);
+                        
+                        // check for valid email
+                        $email_is_valid = validate_email($email);
+                        
+                        // email is not valid
+                          if (!$email_is_valid) {
+                              $a = new stdClass();
+                              $a->row = $line_cnt;
+                              $a->email = $email;
+                              
+                              $error = get_string('invalid_email', 'local_bulkenrol', $a);
+                              
+                              $checked_emails->emails_to_ignore[] = $email;
+                              
+                              if(array_key_exists($line_cnt, $checked_emails->error_messages)){
+                                  $errors = $checked_emails->error_messages[$line_cnt];
+                                  $errors .= "<br>".$error;
+                                  $checked_emails->error_messages[$line_cnt] = $errors;
+                              }else{
+                                  $checked_emails->error_messages[$line_cnt] = $error;
+                              }
+                        }
+                        // email is valid
+                        else {
+                            // get user(s) for email
+                            // check for moodle user with email
+                            list($error, $user_record) = local_bulkenrol_get_user($email);
+                            
+                            if(!empty($error)){
+                                if(array_key_exists($line_cnt, $checked_emails->error_messages)){
+                                    $errors = $checked_emails->error_messages[$line_cnt];
+                                    $errors .= "<br>".$error;
+                                    $checked_emails->error_messages[$line_cnt] = $errors;
+                                }else{
+                                    $checked_emails->error_messages[$line_cnt] = $error;
+                                }
+                                $checked_emails->emails_to_ignore[] = $email;
+                            }
+                            else if(!empty($user_record) && !empty($user_record->id)){
+                                $checked_emails->moodleusers_for_email[$email] = $user_record;
+                                
+                                if(!empty($current_group) && array_key_exists($current_group, $checked_emails->course_groups)){
+                                    $checked_emails->course_groups[$current_group][] = $user_record;
+                                }
+                            }
+                        }
+                    }
+                    // END: iterate emails in row/line
+                    
+                }
+            }
+        }
+        // END: iteriere über Emails (aus Textfeld)
+    }
+
+    return $checked_emails;
+}
+
+function local_bulkenrol_parse_emails($emails) {
+    if (empty($emails)) {
+        return array();
+    } else {
+        $rawlines = explode(PHP_EOL, $emails);
+        $result = array();
+        foreach ($rawlines as $rawline) {
+            $result[] = trim($rawline);
+        }
+        return $result;
+    }
+}
+
+function local_bulkenrol_get_user($email) {
+    global $CFG, $DB;
+    
+    $error = null;
+    $user_record = null;
+    
+    if (empty($email)) {
+        return array($error, $user_record);
+    } else {
+        // get user records for email
+        try {
+            $user_records = $DB->get_records('user', array('email' => $email));
+            $count = count($user_records);
+            if(!empty($count)){
+                // more than one user with email -> ignore email and don't enrol users later!
+                if($count > 1){
+                    $error = get_string('more_than_one_record_for_email', 'local_bulkenrol', $email);
+                }
+                else{
+                    $user_record = current($user_records);
+                }
+            }
+            else{
+                $error = get_string('no_record_found_for_email', 'local_bulkenrol', $email);
+            }
+        } catch (Exception $e) {
+            $error = get_string('error_getting_user_for_email', 'local_bulkenrol', $email).local_bulkenrol_get_exception_info($e);
+        }
+        
+        return array($error, $user_record);
+    }
+}
+
+/**
+ * @param unknown $e should be of instanceof Exception
+ * @return string $e->getMessage()." -> ".$e->getTraceAsString()
+ */
+function local_bulkenrol_get_exception_info($e){
+    if(empty($e) || !($e instanceof Exception) ){
+        return '';
+    }
+    return " ".get_string('exception_info', 'local_bulkenrol').": ".$e->getMessage()." -> ".$e->getTraceAsString();
+}
+
+function local_bulkenrol_users($local_bulkenrol_key){
+    global $CFG, $DB, $SESSION;
+    
+    $error = 'no_data';
+    
+    if(!empty($local_bulkenrol_key)){
+        if(!empty($local_bulkenrol_key) && !empty($SESSION->local_bulkenrol) && array_key_exists($local_bulkenrol_key, $SESSION->local_bulkenrol)){
+            $local_bulkenrol_data = $SESSION->local_bulkenrol[$local_bulkenrol_key];
+            if(!empty($local_bulkenrol_data)){
+                $error = '';
+                
+                $courseid = 0;
+                
+                $tmp_data = explode('_', $local_bulkenrol_key);
+                if(!empty($tmp_data)){
+                    $courseid = $tmp_data[0];
+                }
+                
+                $users_to_enrol = $local_bulkenrol_data->moodleusers_for_email;
+                
+                if(!empty($courseid) && !empty($users_to_enrol)){
+                    $no_data = false;
+                    
+                    try {
+                        $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+                        
+                        $enrolinstances = enrol_get_instances($course->id, false);
+                        
+                        // get enrolment for bulkenrol
+                        $bulkenrol_plugin = get_config('local_bulkenrol','bulkenrol_enrolment');
+                        $plugin = enrol_get_plugin($bulkenrol_plugin);
+                        
+                        $enrolinstance = null;
+                        
+                        foreach ($enrolinstances as $instance) {
+                            // check enrolment
+                            if($bulkenrol_plugin == $instance->enrol){
+                                if ($instance->status != ENROL_INSTANCE_ENABLED) {
+                                    $plugin->update_status($instance, ENROL_INSTANCE_ENABLED);
+                                }
+                                $enrolinstance = $instance;
+                                break;
+                            }
+                        }
+                        
+                        if(empty($enrolinstance)){
+                            $fields = $plugin->get_instance_defaults();
+                            $id = $plugin->add_instance($course, $fields);
+                            
+                            $enrolinstance = $DB->get_record('enrol', array('id' => $id));
+                            $enrolinstance->expirynotify    = $plugin->get_config('expirynotify');
+                            $enrolinstance->expirythreshold = $plugin->get_config('expirythreshold');
+                            $enrolinstance->roleid = $plugin->get_config('roleid');
+                            $enrolinstance->timemodified = time();
+                            $DB->update_record('enrol', $enrolinstance);
+                        }
+                        
+                        if(!empty($enrolinstance)){
+                            // Enrol users in course
+                            $roleid = $enrolinstance->roleid;
+                            foreach ($users_to_enrol as $user) {
+                                $plugin->enrol_user($enrolinstance, $user->id, $roleid);
+                            }
+                        }
+                    } catch (Exception $e) {
+                        $msg = get_string('error_enrol_users', 'local_bulkenrol').local_bulkenrol_get_exception_info($e);
+                        echo html_writer::tag('div', $msg, array('class' => 'local_bulkenrol error'));
+                    }
+                    
+                    // check for course groups to create
+                    $groups = $local_bulkenrol_data->course_groups;
+                    
+                    if(!empty($groups)){
+                        
+                        try {
+                            require_once($CFG->dirroot . '/group/lib.php');
+                            
+                            $existing_course_groups = groups_get_all_groups($courseid);
+                            
+                            foreach ($groups as $name => $members) {
+                                $groupname = trim($name);
+                                
+                                // check if group already exists
+                                $groupid = null;
+                                foreach ($existing_course_groups as $key => $existing_course_group) {
+                                    if($groupname == $existing_course_group->name){
+                                        $groupid = $existing_course_group->id;
+                                        break;
+                                    }
+                                }
+                                // group not found in course -> create new course group
+                                if(empty($groupid)){
+                                    $groupdata = new stdClass();
+                                    $groupdata->courseid = $courseid;
+                                    $groupdata->name = $groupname;
+                                    $groupid = groups_create_group($groupdata, false, false);
+                                }
+                                if(!empty($groupid) && !empty($members)){
+                                    foreach ($members as $key => $member) {
+                                        $user_added = groups_add_member($groupid, $member->id);
+                                    }
+                                }
+                            }
+                        } catch (Exception $e) {
+                            $msg = get_string('error_group_add_members', 'local_bulkenrol').local_bulkenrol_get_exception_info($e);
+                            echo html_writer::tag('div', $msg, array('class' => 'local_bulkenrol error'));
+                        }
+                    }
+                }
+                else{
+                    $error = 'no_courseid_or_no_users_to_enrol';
+                }
+            }
+        }
+    }
+    
+    if(!empty($error)){
+        $msg = get_string($error, 'local_bulkenrol');
+        echo html_writer::tag('div', $msg, array('class' => 'local_bulkenrol error'));
+    }
+    else{
+        $msg = get_string('enrol_users_successful', 'local_bulkenrol');
+        echo html_writer::tag('div', $msg, array('class' => 'local_bulkenrol error'));
+    }
+}
+
+function local_bulkenrol_display_table($local_bulkenrol_data, $key){
+    global $OUTPUT;
+    
+    if(!empty($local_bulkenrol_data) && !empty($key)){
+        
+        switch ($key) {
+            case LOCALBULKENROL_HINT:
+                
+                $data = array();
+                
+                if(!empty($local_bulkenrol_data->error_messages)){
+                    foreach ($local_bulkenrol_data->error_messages as $line => $error_messages) {
+                        $row = array();
+                        
+                        $cell = new html_table_cell();
+                        $cell->text = $line;
+                        $row[] = $cell;
+                        
+                        $cell = new html_table_cell();
+                        $cell->text = $error_messages;
+                        $row[] = $cell;
+                        
+                        $data[] = $row;
+                    }
+                }
+                
+                $table = new html_table();
+                $table->id = "localbulkenrol_hints";
+                $table->attributes['class'] = 'generaltable';
+                $table->tablealign = 'center';
+                $table->summary = get_string('hints_label', 'local_bulkenrol');
+                $table->size = array('10%', '90%');
+                $table->head = array();
+                $table->head[] = get_string('row', 'local_bulkenrol');
+                $table->head[] = get_string('hints_label', 'local_bulkenrol');
+                $table->data = $data;
+                
+                echo $OUTPUT->heading(get_string('hints_label', 'local_bulkenrol'), 3);
+                echo html_writer::tag('div', html_writer::table($table), array('class' => 'flexible-wrap'));
+                
+            break;
+            
+            case LOCALBULKENROL_ENROLUSERS:
+                $data = array();
+                
+                if(!empty($local_bulkenrol_data->moodleusers_for_email)){
+                    foreach ($local_bulkenrol_data->moodleusers_for_email as $email => $user) {
+                        $row = array();
+                        
+                        $cell = new html_table_cell();
+                        $cell->text = $user->email;
+                        $row[] = $cell;
+                        
+                        $cell = new html_table_cell();
+                        $cell->text = $user->firstname;
+                        $row[] = $cell;
+                        
+                        $cell = new html_table_cell();
+                        $cell->text = $user->lastname;
+                        $row[] = $cell;
+                
+                        $data[] = $row;
+                    }
+                }
+                
+                $table = new html_table();
+                $table->id = "localbulkenrol_enrolusers";
+                $table->attributes['class'] = 'generaltable';
+                $table->tablealign = 'center';
+                $table->summary = get_string('users_to_enrol_in_course_label', 'local_bulkenrol');
+                $table->size = array('33%', '33%', '33%');
+                $table->head = array();
+                $table->head[] = get_string('email');
+                $table->head[] = get_string('firstname');
+                $table->head[] = get_string('lastname');
+                $table->data = $data;
+                
+                echo $OUTPUT->heading(get_string('users_to_enrol_in_course_label', 'local_bulkenrol'), 3);
+                echo html_writer::tag('div', html_writer::table($table), array('class' => 'flexible-wrap'));
+                break;
+                
+            default:
+                ;
+            break;
+        }
+    }
+}
+
+function local_bulkenrol_extend_navigation_course($navigation, $course, $context) {
+    global $DB, $SITE, $USER;
+    
+    if(!has_capability('local/bulkenrol:enrolusers', $context)){
+        return;
+    }
+    
+    
+    if (!$usersnode = $navigation->get("users")) {
+        return;
+    }
+    if (!$coursecontext = $context->get_course_context(false)) {
+        return;
+    }
+    
+    $nodeproperties = array(
+                    'text'          => get_string('pluginname','local_bulkenrol'),
+                    'shorttext'     => get_string('pluginname','local_bulkenrol'),
+                    // icon         - The icon to display for the node
+                    // type         - The type of the node
+                    // key          - The key to use to identify the node
+                    // parent       - A reference to the nodes parent
+                    'action'        => new moodle_url('/local/bulkenrol/index.php', array('id' => $coursecontext->instanceid))
+    );
+    
+    $integrationnode = new navigation_node($nodeproperties);
+    
+    $usersnode->add_node($integrationnode);
+
+}

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Local plugin "bulkenrol" - Settings
+ *
+ * @package   local_bulkenrol
+ * @copyright 2017 Soon Systems GmbH on behalf of Alexander Bias, Ulm University <alexander.bias@uni-ulm.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+if ($hassiteconfig) {
+    $settings = new admin_settingpage('local_bulkenrol', get_string('pluginname', 'local_bulkenrol', null, true));
+
+    if ($ADMIN->fulltree) {
+        $enrol_options = array();
+        foreach (enrol_get_plugins(true) as $name => $plugin) {
+            $enrol_options[$name] = get_string('pluginname', 'enrol_'.$name);
+        }
+        
+        $settings->add(
+                new admin_setting_configselect(
+                        'local_bulkenrol/bulkenrol_enrolment',
+                        get_string('bulkenrol_enrolment', 'local_bulkenrol'),
+                        get_string('bulkenrol_enrolment_description', 'local_bulkenrol'),
+                        '',
+                        $enrol_options)
+        );
+        unset($enrol_options);
+    }
+    
+    $ADMIN->add('localplugins', $settings);
+
+}

--- a/version.php
+++ b/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Local plugin "bulkenrol" - Version information
+ *
+ * @package   local_bulkenrol
+ * @copyright 2017 Soon Systems GmbH on behalf of Alexander Bias, Ulm University <alexander.bias@uni-ulm.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'local_bulkenrol';
+$plugin->version = 2017112300;
+$plugin->release = 'v3.2-r1';
+$plugin->requires = 2016052301;
+$plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hallo Alex,

hier die erste Version des Plugins.

Einige Anmerkungen und Fragen habe ich dazu noch.

1. $CFG->allowaccountssameemail == true wird aktuell nicht ausgewertet, sondern es wird generell bei mehreren Usern mit der gleichen Email diese Email beim Import ignoriert. Wenn diese Einstellung nicht gesetzt ist, kann das doch gar nicht vorkommen, dass zwei User dieselbe E-Mail haben, oder?

2. Sollen evtl Fehler/Exceptions angezeigt werden? -> Wenn ja: wo/wie?

3. Sollen Kurs-Gruppen, zu denen (nach Aussortieren von nicht vorhandenen E-Mails oder Fehler) keine User/Mitglieder mehr vorhanden sind, überhaupt angelegt werden?
-> Aktuell werden die Kurs-Gruppen aus dem Textfeld angelegt, auch wenn es dann keine Mitglieder mehr gibt

4. Es fehlen noch englische Übersetzungen und der "Hinweistext mit Nutzungshinweisen zum Plugin"
-> Sollen wir das machen oder übernehmt ihr das?

LG
Michael