### PR TITLE
Distinguish warnings caused by empty line or by invalid content.

### DIFF
--- a/lang/en/local_bulkenrol.php
+++ b/lang/en/local_bulkenrol.php
@@ -31,6 +31,7 @@ $string['enrol_users'] = 'Enrol users';
 $string['enrolinfo_headline'] = 'Enrolment details';
 $string['enrolplugin'] = 'Enrolment plugin';
 $string['enrolplugin_desc'] = 'The enrolment method to be used to bulk enrol the users. If the configured enrolment method is not active / added in the course when the users are bulk-enrolled, it is automatically added / activated.';
+$string['error_empty_line'] = 'Line {$a->line} is empty and will be ignored.';
 $string['error_enrol_users'] = 'There was a problem when enrolling the users to the course.';
 $string['error_enrol_user'] = 'There was a problem when enrolling the user with e-mail <em>{$a->email}</em> to the course.';
 $string['error_exception_info'] = 'Exception information';

--- a/locallib.php
+++ b/locallib.php
@@ -91,7 +91,11 @@ function local_bulkenrol_check_user_mails($emailstextfield, $courseid) {
                 $a = new stdClass();
                 $a->line = $linecnt;
                 $a->content = $emailline;
-                $error = get_string('error_no_email', 'local_bulkenrol', $a);
+        if (trim($a->content != "")) {
+            $error = get_string('error_no_email', 'local_bulkenrol', $a);
+        } else {
+            $error = get_string('error_empty_line', 'local_bulkenrol', $a);
+        }
                 $checkedemails->error_messages[$linecnt] = $error;
 
                 // One email in row/line.

--- a/tests/behat/local_bulkenrol_users.feature
+++ b/tests/behat/local_bulkenrol_users.feature
@@ -203,3 +203,18 @@ Feature: Using the local_bulkenrol plugin for user enrolments
     Then I should see "No valid e-mail address was found in the given list."
     And I should see "Please go back and check your input"
     And "Enrol users" "button" should not exist
+
+  Scenario: Try to bulk enrol a list of mixed invalid users and empty line.
+    When I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I navigate to "Users > User bulk enrolment" in current page administration
+    And I set the field "List of e-mail addresses" to multiline:
+      """
+      student1@example.com
+
+      foo
+      """
+    And I click on "Enrol users" "button"
+    Then I should see "Line 2 is empty and will be ignored."
+    And I should see "No e-mail address found in line 3 (foo). This line will be ignored."
+    And I should see "Manual enrolments"


### PR DESCRIPTION
A lecturer was puzzeled because of a "No e-mail address found in line X (). This line will be ignored." when it was just an empty line causing this.
That lead me to the thought of distinguishing the notices.

However, his opinion was preferrable to be silently discarding notices at all when it was about empty lines.

This solution here gives out a warning saying a line was empty. I myself personally think this is preferrable, it could be based by an exporting error of a third system in the generation of the list to import, and then you want to be noticed.

Best,
Luca