### PR TITLE
Make enrollment instructions gender-neutral

### DIFF
--- a/lang/en/local_bulkenrol.php
+++ b/lang/en/local_bulkenrol.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $string['bulkenrol:enrolusers'] = 'Use user bulk enrolment';
-$string['bulkenrol_form_intro'] = 'Here, you can bulk enrol users to your course. A user to be enrolled is identified by his e-mail address stored in his Moodle account.';
+$string['bulkenrol_form_intro'] = 'Here, you can bulk enrol users to your course. A user to be enrolled is identified by the e-mail address stored in their Moodle account.';
 $string['enrol_users_btn'] = 'Execute user enrolment';
 $string['enrol_users_successful'] = 'User bulk enrolment successful';
 $string['enrolinfo_headline'] = 'Enrolment details';
@@ -78,7 +78,7 @@ $string['user_groups_yes'] = 'User will be added to group';
 $string['user_unenroled_already'] = 'User is not enrolled';
 $string['user_unenroled_yes'] = 'User will be unenrolled';
 $string['usermails'] = 'List of e-mail addresses';
-$string['usermails_help'] = 'To enrol an existing Moodle user into this course, add his e-mail address to this form, one user / e-mail address per line.<br /><br />Example:<br />alice@example.com<br />bob@example.com<br /><br />Optionally, you are able to create groups and add the enrolled users to the groups. All you have to do is to add a heading line with a hash sign and the group\'s name, separating the list of users.<br /><br />Example:<br /># Group 1<br />alice@example.com<br />bob@example.com<br /># Group 2<br />carol@example.com<br />dave@example.com<hr />It is also possible to unenrol users.<br />To do this, preceed the e-mail address with an exclamation mark (!).<br /><br />Example:<br />! alice@example.com<br />! bob@example.com';
+$string['usermails_help'] = 'To enrol an existing Moodle user into this course, add their e-mail address to this form, one user / e-mail address per line.<br /><br />Example:<br />alice@example.com<br />bob@example.com<br /><br />Optionally, you are able to create groups and add the enrolled users to the groups. All you have to do is to add a heading line with a hash sign and the group\'s name, separating the list of users.<br /><br />Example:<br /># Group 1<br />alice@example.com<br />bob@example.com<br /># Group 2<br />carol@example.com<br />dave@example.com<hr />It is also possible to unenrol users.<br />To do this, preceed the e-mail address with an exclamation mark (!).<br /><br />Example:<br />! alice@example.com<br />! bob@example.com';
 $string['users_to_enrol_in_course'] = 'Users to be enrolled into the course';
 $string['users_to_unenrol_from_course'] = 'Users to be unenrolled from the course';
 


### PR DESCRIPTION
Updated enrolment instructions to use gender-neutral language by replacing “his e-mail address” with “their e-mail address” to ensure inclusivity for all users.